### PR TITLE
Improved query string parsing and param access

### DIFF
--- a/src/examples/form_data/main.cpp
+++ b/src/examples/form_data/main.cpp
@@ -33,27 +33,8 @@ int main(int argc, char const* argv[])
 				// example.
 				served::response::stock_reply(400, res);
 			} else {
-				// copy the query string as we will be deleting parts as we
-				// iterate through each key / value pair.
-				std::string query = req.url().query();
-				size_t pos = 0;
-
-				// find each pair of key / value strings delimeted by '&'
-				while ((pos = query.find("&")) != std::string::npos) {
-					// save the key / value pair, and look for the index of the
-					// divider, delimited by '='
-				    std::string pair = query.substr(0, pos);
-					size_t div_index = pair.find('=');
-
-					// write the key and value to the response string, just to
-					// prove we correctly parsed the query string
-					if (div_index != std::string::npos) {
-						res << "Key: " << pair.substr(0, div_index) << ", Value: " 
-							<< pair.substr(div_index + 1, std::string::npos) << "\n";
-					}
-
-					// erase the pair we just processed from the query string
-				    query.erase(0, pos + 1);
+				for ( const auto & query_param : req.query ) {
+					res << "Key: " << query_param.first << ", Value: " << query_param.second << "\n";
 				}
 			}
 		});

--- a/src/served/parameters.hpp
+++ b/src/served/parameters.hpp
@@ -88,6 +88,14 @@ public:
 	 * @return the value of the parameter, or an empty string if the key is not matched.
 	 */
 	const std::string get(std::string const& key) const;
+
+	//  -----  iterators  -----
+
+	parameter_list::iterator begin() { return _list.begin(); }
+	parameter_list::iterator end  () { return _list.end  (); }
+
+	parameter_list::const_iterator begin() const { return _list.begin(); }
+	parameter_list::const_iterator end  () const { return _list.end  (); }
 };
 
 } // served

--- a/src/served/parameters.test.cpp
+++ b/src/served/parameters.test.cpp
@@ -76,3 +76,63 @@ TEST_CASE("Test param const, ref and copy handling", "[parameters]")
 	test_const_copy(params);
 	test_const_ref (params);
 }
+
+TEST_CASE("Test param iteration", "[parameters]")
+{
+	auto values = std::map<std::string, std::string>{{
+		{ "key1", "value1" },
+		{ "key2", "value2" },
+		{ "key3", "value3" },
+		{ "key4", "value4" },
+	}};
+
+	served::parameters params;
+
+	for ( const auto & value : values )
+	{
+		params[value.first] = value.second;
+	}
+
+	auto test_copy = [&](served::parameters p)
+	{
+		int count = 0;
+		for ( const auto & param : p )
+		{
+			count++;
+			CHECK(param.second == values[param.first]);
+		}
+		CHECK(count == values.size());
+	};
+
+	auto test_const_copy = [&](const served::parameters p)
+	{
+		int count = 0;
+		for ( const auto & param : p )
+		{
+			count++;
+			CHECK(param.second == values[param.first]);
+		}
+		CHECK(count == values.size());
+	};
+
+	SECTION("iterate copy params")
+	{
+		test_copy(params);
+	}
+
+	SECTION("iterate const copy params")
+	{
+		test_const_copy(params);
+	}
+
+	SECTION("iterate params")
+	{
+		int count = 0;
+		for ( const auto & param : params )
+		{
+			count++;
+			CHECK(param.second == values[param.first]);
+		}
+		CHECK(count == values.size());
+	}
+}

--- a/src/served/request.hpp
+++ b/src/served/request.hpp
@@ -165,6 +165,7 @@ public:
 	//  -----  public members  -----
 
 	parameters params;
+	parameters query;
 };
 
 } // served

--- a/src/served/request_parser_impl.cpp
+++ b/src/served/request_parser_impl.cpp
@@ -128,7 +128,40 @@ request_parser_impl::query_string( const char * data
                                  , const char * at
                                  , size_t       length )
 {
-	_request.url().set_query(std::string(at, length));
+	std::string query = std::string(at, length);
+	_request.url().set_query(query);
+
+	// find each pair of key / value strings delimeted by '&'
+	while ( query.length() > 0 )
+	{
+		size_t pos = query.find("&");
+
+		std::string pair;
+		if ( pos != std::string::npos )
+		{
+			pair = query.substr(0, pos);
+		}
+		else
+		{
+			pair = query;
+			pos = query.length() - 1;
+		}
+
+		// save the key / value pair, and look for the index of the
+		// divider, delimited by '='
+		size_t div_index = pair.find('=');
+
+		if (div_index != std::string::npos)
+		{
+			std::string key = query_unescape(pair.substr(0, div_index));
+			std::string value = query_unescape(pair.substr(div_index + 1, std::string::npos));
+
+			_request.query[key] = value;
+		}
+
+		// erase the pair we just processed from the query string
+		query.erase(0, pos + 1);
+	}
 }
 
 void


### PR DESCRIPTION
The query string of request URLs will now automatically be parsed for
all requests and stored in req.query as key/value pairs after being URL
unescaped.

The query string of request URLs is now automatically parsed as
key/value pairs. These values are URL unescaped and stored in req.query.

The req.query object is the same served::parameters type as req.params,
and this type has been improved with the ability to iterate. Iterating
all REST params is now as simple as:

for ( auto p : req.params ) {}

And, similarly, for query string key/value pairs:

for ( auto q : req.query ) {}
