### PR TITLE
Served multiplexer now allows handler overrides.

### DIFF
--- a/src/served/methods_handler.hpp
+++ b/src/served/methods_handler.hpp
@@ -47,8 +47,8 @@ typedef std::map<std::string, served_method_list>         served_endpoint_list;
  */
 class methods_handler
 {
-	const std::string                            _path;
-	const std::string                            _info;
+	std::string                                  _path;
+	std::string                                  _info;
 	std::map<served::method, served_req_handler> _handlers;
 
 public:

--- a/src/served/multiplexer.cpp
+++ b/src/served/multiplexer.cpp
@@ -117,8 +117,21 @@ multiplexer::get_segments(const std::string & path)
 served::methods_handler &
 multiplexer::handle(const std::string & path, const std::string info /* = "" */)
 {
+	// Remove any duplicates.
+	for ( auto it = _handler_candidates.begin(); it != _handler_candidates.end(); )
+	{
+		if ( std::get<2>(*it) == path )
+		{
+			it = _handler_candidates.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
 	_handler_candidates.push_back(
-		path_handler_candidate(get_segments(path), served::methods_handler(_base_path + path, info)));
+		path_handler_candidate(get_segments(path), served::methods_handler(_base_path + path, info), path));
 
 	return std::get<1>(_handler_candidates.back());
 }

--- a/src/served/multiplexer.hpp
+++ b/src/served/multiplexer.hpp
@@ -51,11 +51,11 @@ typedef std::function<void(response &, request &)> served_plugin_req_handler;
  */
 class multiplexer
 {
-	typedef std::vector<served_plugin_req_handler>                      plugin_handler_list;
+	typedef std::vector<served_plugin_req_handler>                                   plugin_handler_list;
 
-	typedef std::vector<served::mux::segment_matcher_ptr>               path_compiled_segments;
-	typedef std::tuple<path_compiled_segments, served::methods_handler> path_handler_candidate;
-	typedef std::vector<path_handler_candidate>                         path_handler_candidates;
+	typedef std::vector<served::mux::segment_matcher_ptr>                            path_compiled_segments;
+	typedef std::tuple<path_compiled_segments, served::methods_handler, std::string> path_handler_candidate;
+	typedef std::vector<path_handler_candidate>                                      path_handler_candidates;
 
 	const std::string       _base_path;
 	path_compiled_segments  _base_path_segments;


### PR DESCRIPTION
The served multiplexer now allows you to override a specific handler
pattern. Previous behaviour was to simply append the new matching
handler onto the end of the handler stack, and therefore it would never
be called since any match would already be dispatched to the first
definition.

The new behaviour is that any handler definition whose pattern matches
an existing handler will remove the previous handler from the stack
before being appended to the end.

This means for resolving the order of precendence of an overriding
handler you simply follow the sames rules as if the original overriden
handler had never existed, rather than assuming that the new handler
takes the position of the original.

For example, given the following handler definitions:

handle("/foo").get(foo);
handle("/"   ).get(bar);
handle("/foo").get(baz); // Overrides the previous by removing it

And the following request:

GET /foo HTTP/1.1

The handler 'bar' is called since it matches and comes before the
new '/foo' handler.
