### PR TITLE
WIP: Change enum style to prevent name clashes

### DIFF
--- a/src/served/methods.hpp
+++ b/src/served/methods.hpp
@@ -31,8 +31,8 @@ namespace served {
 /*
  * HTTP method enum
  */
-enum method {
-	GET, POST, HEAD, PUT, DELETE, OPTIONS, TRACE, CONNECT, BREW
+enum class method {
+	Get, Post, Head, Put, Delete, Options, Trace, Connect, Brew
 };
 
 /*
@@ -43,27 +43,27 @@ enum method {
  * @return the method enum as a string
  */
 inline std::string
-method_to_string(enum method m)
+method_to_string(method m)
 {
 	switch(m)
 	{
-		case method::GET:
+		case method::Get:
 			return "GET";
-		case method::POST:
+		case method::Post:
 			return "POST";
-		case method::HEAD:
+		case method::Head:
 			return "HEAD";
-		case method::PUT:
+		case method::Put:
 			return "PUT";
-		case method::DELETE:
+		case method::Delete:
 			return "DELETE";
-		case method::OPTIONS:
+		case method::Options:
 			return "OPTIONS";
-		case method::TRACE:
+		case method::Trace:
 			return "TRACE";
-		case method::CONNECT:
+		case method::Connect:
 			return "CONNECT";
-		case method::BREW:
+		case method::Brew:
 			return "BREW";
 	}
 	return "";
@@ -76,35 +76,35 @@ method_to_string(enum method m)
  *
  * @return the string converted to an enum
  */
-inline enum method
+inline method
 method_from_string(const std::string & str)
 {
 	if ( "GET" == str ) {
-		return method::GET;
+		return method::Get;
 	}
 	if ( "POST" == str ) {
-		return method::POST;
+		return method::Post;
 	}
 	if ( "HEAD" == str ) {
-		return method::HEAD;
+		return method::Head;
 	}
 	if ( "PUT" == str ) {
-		return method::PUT;
+		return method::Put;
 	}
 	if ( "DELETE" == str ) {
-		return method::DELETE;
+		return method::Delete;
 	}
 	if ( "OPTIONS" == str ) {
-		return method::OPTIONS;
+		return method::Options;
 	}
 	if ( "TRACE" == str ) {
-		return method::TRACE;
+		return method::Trace;
 	}
 	if ( "CONNECT" == str ) {
-		return method::CONNECT;
+		return method::Connect;
 	}
 	if ( "BREW" == str ) {
-		return method::BREW;
+		return method::Brew;
 	}
 	throw std::runtime_error("method string not recognised");
 }

--- a/src/served/methods_handler.cpp
+++ b/src/served/methods_handler.cpp
@@ -37,35 +37,35 @@ methods_handler::methods_handler(const std::string path, const std::string info 
 methods_handler &
 methods_handler::get (served_req_handler handler)
 {
-	_handlers[served::method::GET] = handler;
+	_handlers[served::method::Get] = handler;
 	return *this;
 }
 
 methods_handler &
 methods_handler::post(served_req_handler handler)
 {
-	_handlers[served::method::POST] = handler;
+	_handlers[served::method::Post] = handler;
 	return *this;
 }
 
 methods_handler &
 methods_handler::head(served_req_handler handler)
 {
-	_handlers[served::method::HEAD] = handler;
+	_handlers[served::method::Head] = handler;
 	return *this;
 }
 
 methods_handler &
 methods_handler::put (served_req_handler handler)
 {
-	_handlers[served::method::PUT] = handler;
+	_handlers[served::method::Put] = handler;
 	return *this;
 }
 
 methods_handler &
 methods_handler::del (served_req_handler handler)
 {
-	_handlers[served::method::DELETE] = handler;
+	_handlers[served::method::Delete] = handler;
 	return *this;
 }
 

--- a/src/served/methods_handler.test.cpp
+++ b/src/served/methods_handler.test.cpp
@@ -43,16 +43,16 @@ TEST_CASE("test methods handling", "[methods_handler]")
 		auto dummy = [](served::response &, const served::request &) {};
 
 		served::methods_handler h("/dummy");
-		h.post(dummy).get(dummy).method(served::method::CONNECT, dummy).put(dummy);
+		h.post(dummy).get(dummy).method(served::method::Connect, dummy).put(dummy);
 
-		CHECK(h.method_supported(served::method::POST) == true);
-		CHECK(h.method_supported(served::method::GET) == true);
-		CHECK(h.method_supported(served::method::CONNECT) == true);
-		CHECK(h.method_supported(served::method::PUT) == true);
+		CHECK(h.method_supported(served::method::Post) == true);
+		CHECK(h.method_supported(served::method::Get) == true);
+		CHECK(h.method_supported(served::method::Connect) == true);
+		CHECK(h.method_supported(served::method::Put) == true);
 
-		CHECK(h.method_supported(served::method::DELETE) == false);
-		CHECK(h.method_supported(served::method::HEAD) == false);
-		CHECK(h.method_supported(served::method::BREW) == false);
+		CHECK(h.method_supported(served::method::Delete) == false);
+		CHECK(h.method_supported(served::method::Head) == false);
+		CHECK(h.method_supported(served::method::Brew) == false);
 	}
 
 	SECTION("check endpoint propagation no description")
@@ -60,7 +60,7 @@ TEST_CASE("test methods handling", "[methods_handler]")
 		auto dummy = [](served::response &, const served::request &) {};
 
 		served::methods_handler h("/this/path/is/great");
-		h.post(dummy).get(dummy).method(served::method::CONNECT, dummy).put(dummy);
+		h.post(dummy).get(dummy).method(served::method::Connect, dummy).put(dummy);
 
 		served::served_endpoint_list list;
 		h.propagate_endpoint(list);

--- a/src/served/multiplexer.test.cpp
+++ b/src/served/multiplexer.test.cpp
@@ -156,7 +156,7 @@ TEST_CASE("multiplexer path routing", "[mux]")
 
 				served::request req;
 				req.set_destination(url);
-				req.set_method(served::method::GET);
+				req.set_method(served::method::Get);
 
 				served::response res;
 
@@ -171,7 +171,7 @@ TEST_CASE("multiplexer path routing", "[mux]")
 
 				served::request req;
 				req.set_destination(url);
-				req.set_method(served::method::GET);
+				req.set_method(served::method::Get);
 
 				served::response res;
 
@@ -220,7 +220,7 @@ TEST_CASE("multiplexer method routing", "[mux]")
 
 			url.set_path(s1.pattern);
 			req.set_destination(url);
-			req.set_method(served::method::GET);
+			req.set_method(served::method::Get);
 
 			mux.forward_to_handler( res, req );
 
@@ -242,19 +242,19 @@ TEST_CASE("multiplexer method routing", "[mux]")
 			req.set_destination(url);
 
 			INFO("Checking accepts PUT");
-			req.set_method(served::method::PUT);
+			req.set_method(served::method::Put);
 			CHECK_NOTHROW(mux.forward_to_handler( res, req ));
 
 			INFO("Checking accepts DEL");
-			req.set_method(served::method::DELETE);
+			req.set_method(served::method::Delete);
 			CHECK_NOTHROW(mux.forward_to_handler( res, req ));
 
 			INFO("Checking accepts HEAD");
-			req.set_method(served::method::HEAD);
+			req.set_method(served::method::Head);
 			CHECK_NOTHROW(mux.forward_to_handler( res, req ));
 
 			INFO("Checking accepts POST");
-			req.set_method(served::method::POST);
+			req.set_method(served::method::Post);
 			CHECK_NOTHROW(mux.forward_to_handler( res, req ));
 
 			INFO("Checking for correct routing (4 requests)");
@@ -293,7 +293,7 @@ TEST_CASE("multiplexer overwriting", "[mux]")
 
 			url.set_path(s1.pattern);
 			req.set_destination(url);
-			req.set_method(served::method::POST);
+			req.set_method(served::method::Post);
 
 			mux.forward_to_handler( res, req );
 
@@ -315,15 +315,15 @@ TEST_CASE("multiplexer overwriting", "[mux]")
 			req.set_destination(url);
 
 			INFO("Checking accepts GET");
-			req.set_method(served::method::GET);
+			req.set_method(served::method::Get);
 			CHECK_NOTHROW(mux.forward_to_handler( res, req ));
 
 			INFO("Checking accepts HEAD");
-			req.set_method(served::method::HEAD);
+			req.set_method(served::method::Head);
 			CHECK_NOTHROW(mux.forward_to_handler( res, req ));
 
 			INFO("Checking accepts PUT");
-			req.set_method(served::method::PUT);
+			req.set_method(served::method::Put);
 			CHECK_NOTHROW(mux.forward_to_handler( res, req ));
 
 			INFO("Checking for no routed requests to overridden handler (0 requests)");
@@ -357,7 +357,7 @@ TEST_CASE("multiplexer hierarchy test", "[mux]")
 
 		url.set_path("/first/second");
 		req.set_destination(url);
-		req.set_method(served::method::GET);
+		req.set_method(served::method::Get);
 
 		mux.forward_to_handler( res, req );
 
@@ -385,7 +385,7 @@ TEST_CASE("multiplexer hierarchy test", "[mux]")
 
 		url.set_path("/first/second");
 		req.set_destination(url);
-		req.set_method(served::method::GET);
+		req.set_method(served::method::Get);
 
 		mux.forward_to_handler( res, req );
 
@@ -408,7 +408,7 @@ TEST_CASE("multiplexer REST params test", "[mux]")
 
 		url.set_path("/base/expected_123/end");
 		req.set_destination(url);
-		req.set_method(served::method::GET);
+		req.set_method(served::method::Get);
 
 		mux.forward_to_handler( res, req );
 
@@ -437,7 +437,7 @@ TEST_CASE("multiplexer test base path", "[mux]")
 
 			url.set_path("/base/path/end");
 			req.set_destination(url);
-			req.set_method(served::method::GET);
+			req.set_method(served::method::Get);
 
 			mux.forward_to_handler( res, req );
 			CHECK( res.status() == served::status_2XX::ACCEPTED );
@@ -449,7 +449,7 @@ TEST_CASE("multiplexer test base path", "[mux]")
 
 			url.set_path("/base/path/");
 			req.set_destination(url);
-			req.set_method(served::method::GET);
+			req.set_method(served::method::Get);
 
 			mux.forward_to_handler( res, req );
 			CHECK( res.status() == served::status_2XX::NO_CONTENT );
@@ -461,7 +461,7 @@ TEST_CASE("multiplexer test base path", "[mux]")
 
 			url.set_path("/base/not/end");
 			req.set_destination(url);
-			req.set_method(served::method::GET);
+			req.set_method(served::method::Get);
 
 			CHECK_THROWS_AS(mux.forward_to_handler(res, req), served::request_error);
 		}
@@ -481,7 +481,7 @@ TEST_CASE("multiplexer test base path", "[mux]")
 
 		url.set_path("/base/expected_123/end");
 		req.set_destination(url);
-		req.set_method(served::method::GET);
+		req.set_method(served::method::Get);
 
 		mux.forward_to_handler( res, req );
 
@@ -521,7 +521,7 @@ TEST_CASE("multiplexer test plugins", "[mux]")
 
 		url.set_path("/test");
 		req.set_destination(url);
-		req.set_method(served::method::GET);
+		req.set_method(served::method::Get);
 
 		mux.forward_to_handler(res, req);
 		mux.on_request_handled(res, req);
@@ -573,7 +573,7 @@ TEST_CASE("multiplexer test wrapped plugins", "[mux]")
 
 		url.set_path("/test");
 		req.set_destination(url);
-		req.set_method(served::method::GET);
+		req.set_method(served::method::Get);
 
 		mux.forward_to_handler(res, req);
 		mux.on_request_handled(res, req);
@@ -719,7 +719,7 @@ TEST_CASE("multiplexer endpoint list YAML", "[mux]")
 
 		served::request req;
 		req.set_destination(url);
-		req.set_method(served::method::GET);
+		req.set_method(served::method::Get);
 
 		served::response res;
 

--- a/src/served/net/connection.hpp
+++ b/src/served/net/connection.hpp
@@ -46,11 +46,11 @@ class connection
 	: public std::enable_shared_from_this<connection>
 {
 public:
-	enum status_type { READING = 0, DONE };
+	enum status { Reading = 0, Done };
 
 private:
 	boost::asio::io_service &    _io_service;
-	status_type                  _status;
+	status                       _status;
 	boost::asio::ip::tcp::socket _socket;
 	connection_manager &         _connection_manager;
 	multiplexer        &         _request_handler;

--- a/src/served/request.cpp
+++ b/src/served/request.cpp
@@ -34,7 +34,7 @@ namespace served {
 void
 request::clear()
 {
-	_method = served::method::GET;
+	_method = served::method::Get;
 	_destination = uri();
 	_HTTP_version = "";
 	_source = "";
@@ -42,7 +42,7 @@ request::clear()
 }
 
 void
-request::set_method(const enum method & method)
+request::set_method(const served::method & method)
 {
 	_method = method;
 }
@@ -91,7 +91,7 @@ request::url()
 
 //  -----  component accessors  -----
 
-enum method
+served::method
 request::method() const
 {
 	return _method;

--- a/src/served/request.hpp
+++ b/src/served/request.hpp
@@ -48,12 +48,12 @@ class request
 	// Appropriate map type for request may differ from response
 	typedef std::unordered_map<std::string, std::string> header_list;
 
-	enum method _method;
-	uri         _destination;
-	std::string _HTTP_version;
-	std::string _source;
-	header_list _headers;
-	std::string _body;
+	served::method _method;
+	uri            _destination;
+	std::string    _HTTP_version;
+	std::string    _source;
+	header_list    _headers;
+	std::string    _body;
 
 public:
 	//  -----  mutators  -----
@@ -68,7 +68,7 @@ public:
 	 *
 	 * @param method the HTTP method
 	 */
-	void set_method(const enum method & method);
+	void set_method(const served::method & method);
 
 	/*
 	 * Set the destination of this request.
@@ -127,7 +127,7 @@ public:
 	 *
 	 * @return HTTP method of the request
 	 */
-	enum method method() const;
+	served::method method() const;
 
 	/*
 	 * Get the URL of this request.

--- a/src/served/request_parser.cpp
+++ b/src/served/request_parser.cpp
@@ -3449,15 +3449,15 @@ request_parser::get_status()
 {
 	if ( parser_error() )
 	{
-		return ERROR;
+		return status::Error;
 	}
 	else if ( parser_finished() )
 	{
-		return FINISHED;
+		return status::Finished;
 	}
 	else
 	{
-		return RUNNING;
+		return status::Running;
 	}
 }
 

--- a/src/served/request_parser.hpp
+++ b/src/served/request_parser.hpp
@@ -56,7 +56,7 @@ class request_parser {
 
 public:
 
-	enum status { RUNNING = 0, FINISHED, ERROR };
+	enum class status { Running = 0, Finished, Error };
 
 private:
 	/*

--- a/src/served/request_parser.rl
+++ b/src/served/request_parser.rl
@@ -270,15 +270,15 @@ request_parser::get_status()
 {
 	if ( parser_error() )
 	{
-		return ERROR;
+		return status::Error;
 	}
 	else if ( parser_finished() )
 	{
-		return FINISHED;
+		return status::Finished;
 	}
 	else
 	{
-		return RUNNING;
+		return status::Running;
 	}
 }
 

--- a/src/served/request_parser.test.cpp
+++ b/src/served/request_parser.test.cpp
@@ -143,7 +143,7 @@ TEST_CASE("request parser can parse http requests", "[request_parser]")
 	{
 		SECTION("will parse header without errors")
 		{
-			REQUIRE(served::request_parser::FINISHED == parser.get_status());
+			REQUIRE(served::request_parser::status::Finished == parser.get_status());
 		}
 		SECTION("parse returns offset to beginning of content")
 		{
@@ -205,7 +205,7 @@ TEST_CASE("request parser can handle utf-8", "[request_parser]")
 	{
 		SECTION("will parse header without errors")
 		{
-			REQUIRE(served::request_parser::FINISHED == parser.get_status());
+			REQUIRE(served::request_parser::status::Finished == parser.get_status());
 		}
 		SECTION("parse returns offset to beginning of content")
 		{
@@ -272,7 +272,7 @@ TEST_CASE("request parser can handle request in chunks", "[request_parser]")
 	{
 		SECTION("will parse chunked header without errors")
 		{
-			REQUIRE(parser.get_status() == mock_request_parser::FINISHED);
+			REQUIRE(parser.get_status() == mock_request_parser::status::Finished);
 		}
 	}
 	SECTION("header is parsed correctly")

--- a/src/served/request_parser_impl.cpp
+++ b/src/served/request_parser_impl.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <string>
+#include <sstream>
 
 namespace served {
 
@@ -224,7 +225,9 @@ request_parser_impl::expecting_body()
 			size_t len = 0;
 			try
 			{
-				len = std::stoi(length);
+				std::stringstream convert;
+				convert << length;
+				convert >> len;
 			}
 			catch (...) {}
 

--- a/src/served/request_parser_impl.hpp
+++ b/src/served/request_parser_impl.hpp
@@ -42,19 +42,19 @@ namespace served {
  */
 class request_parser_impl : public served::request_parser {
 public:
-	enum status_type
+	enum status
 	{
-		ERROR = 0,
-		READ_HEADER,
-		EXPECT_CONTINUE,
-		READ_BODY,
-		FINISHED,
-		REJECTED_REQUEST_SIZE
+		Error = 0,
+		ReadHeader,
+		ExpectContinue,
+		ReadBody,
+		Finished,
+		RejectedRequestSize
 	};
 
 private:
 	request &         _request;
-	status_type       _status;
+	status            _status;
 	size_t            _body_expected;
 	std::stringstream _body_stream;
 	size_t            _max_req_size_bytes;
@@ -70,7 +70,7 @@ public:
 	explicit request_parser_impl(request & req, size_t max_req_size_bytes = 0)
 		: served::request_parser()
 		, _request(req)
-		, _status(status_type::READ_HEADER)
+		, _status(ReadHeader)
 		, _body_expected(0)
 		, _body_stream()
 		, _max_req_size_bytes(max_req_size_bytes)
@@ -85,7 +85,7 @@ public:
 	 *
 	 * @return the new state of the parser
 	 */
-	status_type parse(const char *data, size_t len);
+	status parse(const char *data, size_t len);
 
 protected:
 	/*
@@ -170,7 +170,7 @@ private:
 	 *
 	 * @return status_type of request_parser_impl, FINISHED indicates the body is fully read
 	 */
-	status_type parse_body(const char *data, size_t len);
+	status parse_body(const char *data, size_t len);
 };
 
 } // served namespace


### PR DESCRIPTION
Hi again :)

The library now builds on Windows and with the Android NDK toolchain ( BTW, I also successfully tested on iOS, but I didn't need to make any changes for that to work).

Unfortunately I had to change the style of the enums, which is a rather disruptive change.
The reason for this is that certain windows headers (annoyingly) defines the MACROs ``ERROR`` and ``DELETE``.
Another way of fixing this issue would be to use the directive ``#undef``, but to me it seems unsafe and intrusive to undefine such macros - I guess they could be used somewhere.

I would also like to change ``status.hpp`` to be an enum and then use this new style for consistency - but that is a bit tedious work, so I will only do it if you like the idea :)

Let me know what you think.