### PR TITLE
Add pkgconfig support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,12 @@ FOREACH (CONFIGINPUT ${CONFIGINPUTS})
 ENDFOREACH (CONFIGINPUT ${CONFIGINPUTS})
 
 #
+# pkg-config file generator
+#
+CONFIGURE_FILE("install/pkgconfig/served.pc.in" "${LIBRARY_OUTPUT_PATH}/pkgconfig/served.pc" @ONLY)
+INSTALL(FILES "${LIBRARY_OUTPUT_PATH}/pkgconfig/served.pc" DESTINATION lib/pkgconfig )
+
+#
 # Add Build Targets
 #
 IF (SERVED_BUILD_TESTS)

--- a/install/pkgconfig/served.pc.in
+++ b/install/pkgconfig/served.pc.in
@@ -1,0 +1,11 @@
+prefix=${pcfiledir}/../../
+libdir=${pcfiledir}/../
+includedir=${prefix}/include
+
+Name: served
+Description: @APPLICATION_NAME@
+URL: https://github.com/meltwater/served
+Version: @APPLICATION_VERSION_STRING@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lserved
+


### PR DESCRIPTION
Add pkgconfig file, with automatic generation, usable both during build phase and after installation