### PR TITLE
README: require Boost 1.53 or newer instead of 1.56

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Features:
 
 ### Requirements
 
-* [Required] - [Boost 1.56](http://www.boost.org/)
+* [Required] - [Boost (1.53 or newer)](http://www.boost.org/)
 * [Optional] - [Ragel](http://www.complang.org/ragel/)
 
 ### Building


### PR DESCRIPTION
Works properly based on Boost 1.53, therefore no backports from Boost 1.56 are required.

The RPM and DEB cmake rules already specify the following requirements:
```
./cmake/CPackConfigRPM.cmake:    SET(CPACK_RPM_PACKAGE_REQUIRES "libboost >= 1.53")                                 
./cmake/CPackConfigDEB.cmake:    SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost (>= 1.53)")                                    
./cmake/CPackConfigDEB.cmake:    SET(CPACK_DEBIAN_PACKAGE_BUILDS_DEPENDS "libboost-dev (>= 1.53)")                                                            
```

And the Travis configuration uses 1.55.