### PR TITLE
[WIP] Stability: Add stability test example and start multithreaded fixes

### DIFF
--- a/src/examples/stability/CMakeLists.txt
+++ b/src/examples/stability/CMakeLists.txt
@@ -18,14 +18,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-ADD_SUBDIRECTORY (binary_data)
-ADD_SUBDIRECTORY (form_data)
-ADD_SUBDIRECTORY (handlers)
-ADD_SUBDIRECTORY (hello_world)
-ADD_SUBDIRECTORY (hello_world_no_blocking)
-ADD_SUBDIRECTORY (json_data)
-ADD_SUBDIRECTORY (query_params)
-ADD_SUBDIRECTORY (list_endpoints)
-ADD_SUBDIRECTORY (request_logger_plugin)
-ADD_SUBDIRECTORY (rest_resource)
-ADD_SUBDIRECTORY (stability)
+#
+# Locate project sources
+#
+FILE (GLOB_RECURSE eg_stability_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+
+#
+# Configure common project settings
+#
+SET (eg_stability_LIBS ${PROJECT_NAME} ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+#
+# Executable build rules
+#
+ADD_EXECUTABLE (eg_stability ${eg_stability_SRCS})
+TARGET_LINK_LIBRARIES (eg_stability ${eg_stability_LIBS})
+INSTALL (TARGETS eg_stability DESTINATION bin)

--- a/src/examples/stability/main.cpp
+++ b/src/examples/stability/main.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014 MediaSift Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <served/served.hpp>
+#include <unistd.h>
+
+/* stability example
+ *
+ * This example is a basic stability test of served run in non blocking way.
+ */
+void test(bool stop)
+{
+	served::multiplexer mux;
+
+	mux.handle("/hello")
+		.get([](served::response & res, const served::request &) {
+			res << "Hello world";
+		});
+
+	std::cout << "Try this example with:" << std::endl;
+	std::cout << " curl http://localhost:8123/hello" << std::endl;
+
+	served::net::server server("127.0.0.1", "8123", mux, false);
+	server.run(10, false); // Run with a pool of 10 threads (not blocking)
+
+	std::cout << "Time to stop the server" << std::endl;
+	if (stop) {
+		server.stop();
+	}
+}
+
+int main(int, char const**)
+{
+	for (size_t i = 0; i < 10000; ++i) {
+		std::cout << std::endl;
+		std::cout << "Performing test " << i << " (with stop()) :" << std::endl;
+		std::cout << std::endl;
+		test(true);
+	}
+
+	for (size_t i = 0; i < 10000; ++i) {
+		std::cout << std::endl;
+		std::cout << "Performing test " << i << " (without stop()) :" << std::endl;
+		std::cout << std::endl;
+		test(false);
+	}
+
+	std::cout << "Successfully performed the stability tests" << std::endl;
+	std::cout << std::endl;
+	return 0;
+}

--- a/src/served/net/server.hpp
+++ b/src/served/net/server.hpp
@@ -25,6 +25,7 @@
 
 #include <boost/asio.hpp>
 #include <string>
+#include <thread>
 #include <served/net/connection_manager.hpp>
 #include <served/multiplexer.hpp>
 
@@ -49,6 +50,7 @@ class server
 	int                            _read_timeout;
 	int                            _write_timeout;
 	size_t                         _req_max_bytes;
+	std::vector<std::thread>       _threads;
 
 public:
 	server(const server&) = delete;
@@ -69,6 +71,11 @@ public:
 	               , const std::string & port
 	               , multiplexer       & mux
 	               , bool              register_signals = true );
+
+	/*
+	 * Destroys the server.
+	 */
+	~server();
 
 	/*
 	 * A call that prompts the server into listening for HTTP requests.

--- a/src/served/net/server.hpp
+++ b/src/served/net/server.hpp
@@ -77,7 +77,7 @@ public:
 	 * and another param which defines the blocking nature.
 	 *
 	 * @param n_threads the number of threads to pool for request handling
-	 * @param block if n_threads > 0, defines whether this operation is blocking or not
+	 * @param block if n_threads > 1, defines whether this operation is blocking or not
 	 */
 	void run(int n_threads = 1, bool block = true);
 


### PR DESCRIPTION
Served server generates random segmentation faults (SIGSEGV) upon cleanups,
due to race conditions throughout the Boost ASIO io_service destructors.

The issue can be proven with the new "stability" example sources,
iterating through 1000 creations of `served::net::server` with explicit `stop()` calls
and through 1000 creations of `served::net::server` without calling `stop()`.