### PR TITLE
Fix Bazel build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,6 @@
 workspace(name = "com_github_meltwater_served")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "com_github_nelhage_rules_boost",
     commit = "72ec09168e5c3a296f667b3d956a853ccd65c8ed",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ workspace(name = "com_github_meltwater_served")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "com_github_nelhage_rules_boost",
-    commit = "72ec09168e5c3a296f667b3d956a853ccd65c8ed",
+    commit = "552baa34c17984ca873cd0c4fdd010c177737b6f",
     remote = "https://github.com/nelhage/rules_boost",
 )
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")


### PR DESCRIPTION
`git_repository` is no longer a native rule