### PR TITLE
Fix two name clashes with Windows includes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -49,6 +49,10 @@ cc_library(
         "src/served/net/connection_manager.hpp",
         "src/served/net/server.hpp",
     ],
+    defines = select({
+        "@bazel_tools//src/conditions:windows": ["NOGDI"],
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "src/",
     visibility = ["//visibility:public"],
     deps = [

--- a/src/served/methods.hpp
+++ b/src/served/methods.hpp
@@ -26,6 +26,12 @@
 #include <string>
 #include <stdexcept>
 
+#ifdef _MSC_VER
+	// DELETE is also defined as a macro in winnt.h, included through boost::asio
+	#pragma push_macro("DELETE")
+	#undef DELETE
+#endif // _MSC_VER
+
 namespace served {
 
 /*
@@ -115,5 +121,9 @@ method_from_string(const std::string & str)
 }
 
 } // served
+
+#ifdef _MSC_VER
+	#pragma pop_macro("DELETE")
+#endif // _MSC_VER
 
 #endif // SERVED_METHODS_HPP


### PR DESCRIPTION
ERROR is a macro in wingdi.h. It can be avoided by defining NOGDI at build level.
DELETE is a macro in winnt.h. It has to be undefined.

Unfortunately I don't see a better fix except renaming the enum members.
