### PR TITLE
Add caching

### DIFF
--- a/src/served/response.cpp
+++ b/src/served/response.cpp
@@ -71,6 +71,12 @@ response::set_body(const std::string & body)
 	_body.str(body);
 }
 
+void response::set_response(const std::shared_ptr<const std::string> &res)
+{
+	respond_with_cache = true;
+	cache = res;
+}
+
 response&
 response::operator<<(std::string const& rhs)
 {
@@ -98,6 +104,10 @@ response::body_size()
 const std::string &
 response::to_buffer()
 {
+
+	if (respond_with_cache)
+		return *cache;
+
 	std::stringstream ss;
 
 	ss << "HTTP/1.1 " << _status << " " << status::status_to_reason(_status) << "\r\n";

--- a/src/served/response.hpp
+++ b/src/served/response.hpp
@@ -26,6 +26,8 @@
 #include <sstream>
 #include <iostream>
 #include <map>
+#include <memory>
+#include <string>
 
 #include <served/status.hpp>
 
@@ -51,6 +53,10 @@ class response
 	header_list       _headers;
 	std::stringstream _body;
 	std::string       _buffer;
+
+	bool respond_with_cache{false};
+	std::shared_ptr<const std::string> cache;
+
 
 public:
 	//  -----  constructors  -----
@@ -93,6 +99,15 @@ public:
 	 * @param body the response body
 	 */
 	void set_body(const std::string & body);
+
+	/*
+	 * Set the entire response.
+	 *
+	 * Sets the entire response, discarding any previous data stored in both the headers and the body.
+	 *
+	 * @param res the response buffer
+	 */
+	void set_response(const std::shared_ptr<const std::string> &res);
 
 	/*
 	 * Pipe data to the body of the response.


### PR DESCRIPTION
### motivation
Serving static files with Served is painfully slow and has a terrible memory footprint. 
`served::response::to_buffer()` seems to copy a lot.

### proposed user facing changes
Add a single methode
```c++
void response::set_response(const std::shared_ptr<const std::string> &res)
```
### possible usage
```c++
std::function<void(served::response &res, const served::request &)>
serve_file(const std::string &file_name, const std::string &file_extension)
{
	// load file in memory
	const std::string filename{file_name + "." + file_extension};
	std::ifstream	 ifs{file_name + "." + file_extension,
					  std::ios::in | std::ios::binary};
	const std::string file{(std::istreambuf_iterator<char>(ifs)),
						   std::istreambuf_iterator<char>()};

	// generate first response and cache it
	served::response my_res{};
	my_res.set_header("content-type", content_type(file_extension));
	my_res.set_body(file);
	const auto response_buffer{std::make_shared<const std::string>(my_res.to_buffer())};

	return
		[response_buffer](served::response &res, const served::request & /*unused*/) {
			res.set_response(response_buffer);
		};
}

```

```c++
mux.handle("/large_image.jpg").get(serve_file("large_image", "jpg"));
```

### benchmarks
Serving a 13MB image over 100 connections 1000 times. Measured via ApacheBench 2.3.
```
Concurrency Level:      100
Time taken for tests:   2.357 seconds
Complete requests:      1000
Failed requests:        0
Keep-Alive requests:    0
Total transferred:      14488596000 bytes
HTML transferred:       14488498000 bytes
Requests per second:    424.24 [#/sec] (mean)
Time per request:       235.718 [ms] (mean)
Time per request:       2.357 [ms] (mean, across all concurrent requests)
Transfer rate:          6002519.76 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   1.0      0       5
Processing:   178  233  12.7    235     280
Waiting:        0    6  10.0      3      64
Total:        178  234  12.6    235     280

Percentage of the requests served within a certain time (ms)
  50%    235
  66%    236
  75%    237
  80%    237
  90%    243
  95%    243
  98%    266
  99%    273
 100%    280 (longest request)
```
 About 6 to 7  Gbit/s on a single mobile core. That's faster than nginx in both response time and troughput on my machine, although cpu usage remains higher.