### PR TITLE
Exposes the request headers, as const reference

### DIFF
--- a/src/served/request.cpp
+++ b/src/served/request.cpp
@@ -138,4 +138,10 @@ request::body() const
 	return _body;
 }
 
+const request::header_list&
+request::get_headers() const
+{
+	return _headers;
+}
+
 } // served

--- a/src/served/request.hpp
+++ b/src/served/request.hpp
@@ -166,6 +166,13 @@ public:
 	 */
 	const std::string body() const;
 
+	/*
+	 * Get all headers. Read-only, to be used when one wants to iterate over the headers.
+	 *
+	 * @return header_list as const reference.
+	 */
+	const header_list& get_headers() const;
+
 public:
 	//  -----  public members  -----
 


### PR DESCRIPTION
Makes iteration over all headers easier, instead of solely having to query with request::header(std::string const& key).