### PR TITLE
Allowing DELETE method to have a body

### DIFF
--- a/src/served/request_parser_impl.cpp
+++ b/src/served/request_parser_impl.cpp
@@ -243,6 +243,7 @@ request_parser_impl::expecting_body()
 	case method::PUT:
 	case method::POST:
 	case method::PATCH:
+        case method::DELETE:
 	{
 		std::string type   = _request.header("content-type");
 		std::string length = _request.header("content-length");


### PR DESCRIPTION
Hi. The specification does not explicitly prohibit the presence of a body for the DELETE method.